### PR TITLE
Updated message for project name

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -32,7 +32,7 @@ module.exports = class extends Generator {
         type: "input",
         name: "toolNameHuman",
         message:
-          'Thanks! Now, give me a human name for the project - e.g. "Genome Browser"',
+          'Thanks! Now, give me a human name for the project with only letters and NO special characters. e.g. "Genome Browser"',
         default: "BioJS component"
       }
     ];


### PR DESCRIPTION
The message which asked the project name was unclear and didn't
ask users to not include any special characters in it which resulted
in errors later if they included hyphen (for example), this fixes that
by changing the message.
Fixes #5.