### PR TITLE
Updated the generator name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@biojs/generator-biojs-webcomponents",
+  "name": "generator-biojs-webcomponents",
   "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@biojs/generator-biojs-webcomponents",
+  "name": "generator-biojs-webcomponents",
   "version": "1.0.1",
   "description": "Generate the scaffold for a BioJS component automatically so you don't have to do it yourself",
   "homepage": "http://biojs.net",


### PR DESCRIPTION
The criteria for our generator to appear in Yeoman'registry (on its website)
is to start the generator's name with "generator-", this does that
by removing the "@biojs/" from the name.