### PR TITLE
Fixed typo in templates

### DIFF
--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -86,6 +86,5 @@ export const <%= toolNameCamel %> = {
   init: initComponent()
 };
 
-// this line connects the html element in idex.html with the javascript
-// defined above.
+// this line connects the html element in index.html with the javascript defined above.
 define('<%=toolNameComputer%>', <%= toolNameCamel %>);


### PR DESCRIPTION
This fixes a typo in generators/app/templates/src/index.js.