### PR TITLE
Added option to overwrite or rename if build directory exists

### DIFF
--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -91,6 +91,25 @@ describe("generator-biojs-webcomponents:app - Upgrade an existing component by i
   it("skips the current question if user enters skip", async () => {
     assert.equal(await validators.importBuildFileLocally("skip"), true);
   });
+  it("renames the directory in which build file will be imported", async () => {
+    await validators
+      .renameDirectory("test-directory")
+      .then(() => assert.file(["test-directory", "component-dist"]));
+  });
+  it("pastes the build file in renamed directory", async () => {
+    await validators
+      .importBuildFileInRenamedDirectory(path.join(__dirname, "../LICENSE"), {
+        renameDirectory: "test-directory"
+      })
+      .then(() => assert.file(["test-directory/LICENSE"]));
+  });
+  it("overwrites the directory content", async () => {
+    await validators
+      .overwriteDirectoryContent(path.join(__dirname, "../README.md"))
+      .then(() => {
+        assert.file(["component-dist/README.md"]);
+      });
+  });
   it("throws an error if user enters an empty string as path of build file", async () => {
     assert.equal(
       await validators.importBuildFileFromNPM(""),

--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -88,14 +88,6 @@ describe("generator-biojs-webcomponents:app - Upgrade an existing component by i
         assert.file(["component-dist/validator.js"]);
       });
   });
-  it("only pastes the build file", async () => {
-    // This will work as the directory component-dist already exists because of the above test
-    await validators
-      .copyBuildFileLocally(path.join(__dirname, "../LICENSE"))
-      .then(() => {
-        assert.file(["component-dist/LICENSE"]);
-      });
-  });
   it("skips the current question if user enters skip", async () => {
     assert.equal(await validators.importBuildFileLocally("skip"), true);
   });
@@ -105,9 +97,9 @@ describe("generator-biojs-webcomponents:app - Upgrade an existing component by i
       chalk.red("This is a mandatory field, please answer.")
     );
   });
-  it("throws an error if user enters an empty string as path of build file to be copied", async () => {
+  it("throws an error if user enters an empty string as the name for directory in which build file will be imported", async () => {
     assert.equal(
-      await validators.copyBuildFileLocally(""),
+      await validators.renameDirectory(""),
       chalk.red("This is a mandatory field, please answer.")
     );
   });

--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -99,13 +99,16 @@ describe("generator-biojs-webcomponents:app - Upgrade an existing component by i
   it("pastes the build file in renamed directory", async () => {
     await validators
       .importBuildFileInRenamedDirectory(path.join(__dirname, "../LICENSE"), {
-        renameDirectory: "test-directory"
+        renameDirectoryLocal: "test-directory"
       })
       .then(() => assert.file(["test-directory/LICENSE"]));
   });
   it("overwrites the directory content", async () => {
     await validators
-      .overwriteDirectoryContent(path.join(__dirname, "../README.md"))
+      .overwriteDirectoryContent(path.join(__dirname, "../README.md"), {
+        renameOrOverwriteLocal:
+          "Overwrite the files in the existing component-dist directory."
+      })
       .then(() => {
         assert.file(["component-dist/README.md"]);
       });
@@ -125,7 +128,7 @@ describe("generator-biojs-webcomponents:app - Upgrade an existing component by i
 });
 
 describe("generator-biojs-webcomponents:app - Upgrade an existing component by importing build file using npm", () => {
-  it("works successfully if the package name and version entered is correct", async () => {
+  it("throws an error if version entered does not exist", async () => {
     assert.equal(
       await validators.version("fkdk", { packageName: "node" }),
       chalk.red(
@@ -139,16 +142,6 @@ describe("generator-biojs-webcomponents:app - Upgrade an existing component by i
   });
   it("skips the current question if user enters skip", async () => {
     assert.equal(await validators.importBuildFileFromNPM("skip"), true);
-  });
-  it("downloads the file if URL entered is correct", async () => {
-    // This will work as the directory component-dist is already created above
-    await validators
-      .copyBuildFileFromNPM(
-        "https://cdn.jsdelivr.net/npm/ProtVista@2.0.13/build/protvista.min.gz.js"
-      )
-      .then(() => {
-        assert.file(["component-dist/protvista.min.gz.js"]);
-      });
   });
   it("throws an error if an npm package doesn't exist", async () => {
     assert.equal(
@@ -179,12 +172,6 @@ describe("generator-biojs-webcomponents:app - Upgrade an existing component by i
   it("throws an error if downloadURL entered is empty", async () => {
     assert.equal(
       await validators.importBuildFileFromNPM(""),
-      chalk.red("This is a mandatory field, please answer.")
-    );
-  });
-  it("throws an error if downloadURL for build file to copied entered is empty", async () => {
-    assert.equal(
-      await validators.copyBuildFileFromNPM(""),
       chalk.red("This is a mandatory field, please answer.")
     );
   });

--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -79,6 +79,11 @@ describe("generator-biojs-webcomponents:app - Make a new Web Component", () => {
 });
 
 describe("generator-biojs-webcomponents:app - Upgrade an existing component by importing build file locally", () => {
+  it("makes a new directory named - component-dist", async () => {
+    await validators
+      .directoryName("component-dist")
+      .then(() => assert.file(["component-dist"]));
+  });
   it("imports the build file", async () => {
     await validators
       .importBuildFileLocally(
@@ -88,40 +93,9 @@ describe("generator-biojs-webcomponents:app - Upgrade an existing component by i
         assert.file(["component-dist/validator.js"]);
       });
   });
-  it("skips the current question if user enters skip", async () => {
-    assert.equal(await validators.importBuildFileLocally("skip"), true);
-  });
-  it("renames the directory in which build file will be imported", async () => {
-    await validators
-      .renameDirectory("test-directory")
-      .then(() => assert.file(["test-directory", "component-dist"]));
-  });
-  it("pastes the build file in renamed directory", async () => {
-    await validators
-      .importBuildFileInRenamedDirectory(path.join(__dirname, "../LICENSE"), {
-        renameDirectoryLocal: "test-directory"
-      })
-      .then(() => assert.file(["test-directory/LICENSE"]));
-  });
-  it("overwrites the directory content", async () => {
-    await validators
-      .overwriteDirectoryContent(path.join(__dirname, "../README.md"), {
-        renameOrOverwriteLocal:
-          "Overwrite the files in the existing component-dist directory."
-      })
-      .then(() => {
-        assert.file(["component-dist/README.md"]);
-      });
-  });
   it("throws an error if user enters an empty string as path of build file", async () => {
     assert.equal(
       await validators.importBuildFileFromNPM(""),
-      chalk.red("This is a mandatory field, please answer.")
-    );
-  });
-  it("throws an error if user enters an empty string as the name for directory in which build file will be imported", async () => {
-    assert.equal(
-      await validators.renameDirectory(""),
       chalk.red("This is a mandatory field, please answer.")
     );
   });
@@ -133,15 +107,12 @@ describe("generator-biojs-webcomponents:app - Upgrade an existing component by i
       await validators.version("fkdk", { packageName: "node" }),
       chalk.red(
         "Sorry, the version - " +
-          chalk.red.bold("fkdk") +
+          chalk.yellow("fkdk") +
           " doesn't exist. Please enter again. Enter " +
           chalk.cyan("latest") +
           " if you want to import the latest version."
       )
     );
-  });
-  it("skips the current question if user enters skip", async () => {
-    assert.equal(await validators.importBuildFileFromNPM("skip"), true);
   });
   it("throws an error if an npm package doesn't exist", async () => {
     assert.equal(

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -204,7 +204,7 @@ module.exports = class extends Generator {
         type: "input",
         name: "importBuildFileInRenamedDirectoryNpm",
         message:
-          "Great! Now enter the path of the build file to import it in the renamed directory.",
+          "Great! Now enter the URL of the build file to import it in the renamed directory.",
         when: function(responses) {
           if (
             responses.renameOrOverwriteNpm ===
@@ -220,7 +220,7 @@ module.exports = class extends Generator {
       {
         type: "input",
         name: "overwriteDirectoryContentNpm",
-        message: `Enter the path of the build file. Please note that this will overwrite all the existing content in ${chalk.cyan(
+        message: `Enter the URL of the build file. Please note that this will overwrite all the existing content in ${chalk.cyan(
           "component-dist"
         )}.`,
         when: function(responses) {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -201,18 +201,73 @@ module.exports = class extends Generator {
         validate: validators.importBuildFileLocally
       },
       {
-        type: "input",
-        name: "copyBuildFileLocally",
-        message:
-          "Please enter the path of the build file, we will paste it into the existing directory.",
+        type: "list",
+        name: "renameOrOverwrite",
+        message: "What do you want to do?",
+        choices: [
+          "Rename the component-dist directory we are making.",
+          "Overwrite the files in the existing component-dist directory."
+        ],
         when: function(responses) {
           if (responses.importBuildFileLocally === "skip") {
             return true; // Show this prompt if user says that package description is correct
           }
 
           return false; // Don't show this prompt if user says that package description is incorrect
+        }
+      },
+      {
+        type: "input",
+        name: "renameDirectory",
+        message: `Enter the name of the directory in which you want to import the build file, make sure it is not ${chalk.cyan(
+          "dist"
+        )} or ${chalk.cyan("component-dist")}.`,
+        when: function(responses) {
+          if (
+            responses.renameOrOverwrite ===
+            "Rename the component-dist directory we are making."
+          ) {
+            return true;
+          }
+
+          return false;
         },
-        validate: validators.copyBuildFileLocally
+        validate: validators.renameDirectory
+      },
+      {
+        type: "input",
+        name: "importBuildFileInRenamedDirectory",
+        message:
+          "Great! Now enter the path of the build file to import it in the renamed directory.",
+        when: function(responses) {
+          if (
+            responses.renameOrOverwrite ===
+            "Rename the component-dist directory we are making."
+          ) {
+            return true;
+          }
+
+          return false;
+        },
+        validate: validators.importBuildFileInRenamedDirectory
+      },
+      {
+        type: "input",
+        name: "overwriteDirectoryContent",
+        message: `Enter the path of the build file. Please note that this will overwrite all the existing content in ${chalk.cyan(
+          "component-dist"
+        )}.`,
+        when: function(responses) {
+          if (
+            responses.renameOrOverwrite ===
+            "Overwrite the files in the existing component-dist directory."
+          ) {
+            return true;
+          }
+
+          return false;
+        },
+        validate: validators.overwriteDirectoryContent
       }
     ];
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -41,11 +41,11 @@ module.exports = class extends Generator {
         type: "rawlist",
         name: "importFrom",
         message:
-          "We need the build file (generally index.js, main.js or componentName.js) for this, import it using one of the options -",
+          "I need the build file (generally index.js, main.js or componentName.js) for this, import it using one of the options -",
         choices: [
           "Install component from npm package (Recommended - fastest way)",
-          "Tell us the path of the build file on your local machine and we will import it in the project.",
-          "Tell us the npm package name, version, build file URL and we will download the build file."
+          "Tell us the path of the build file on your local machine and I will import it in the project.",
+          "Tell us the npm package name, version, build file URL and I will download the build file."
         ],
         default: 0
       }
@@ -84,7 +84,7 @@ module.exports = class extends Generator {
         type: "input",
         name: "checkVersionAndInstallComponent",
         message:
-          "Great! We will import the latest version of the npm package, if you don't want this, enter the version.",
+          "Great! I will import the latest version of the npm package, if you don't want this, enter the version.",
         default: "latest",
         when: function(responses) {
           if (responses.confirmPackageNameToInstallComponent) {
@@ -131,7 +131,7 @@ module.exports = class extends Generator {
         type: "input",
         name: "version",
         message:
-          "Great! We will import the latest version of your file from the npm package, if you don't want this, enter the version.",
+          "Great! I will import the latest version of your file from the npm package, if you don't want this, enter the version.",
         default: "latest",
         when: function(responses) {
           if (responses.confirmPackageName) {
@@ -141,6 +141,14 @@ module.exports = class extends Generator {
           return false; // Don't show this prompt if user says that package description is incorrect
         },
         validate: validators.version
+      },
+      {
+        type: "input",
+        name: "directoryName",
+        message:
+          "The build file will be imported in a separate directory in the project's root. Enter the name of this directory or press Enter if you like to go with default.",
+        validate: validators.directoryName,
+        default: "component-dist"
       },
       {
         type: "input",
@@ -154,7 +162,7 @@ module.exports = class extends Generator {
                 "?version=" +
                 answers.version
             ) +
-            " contains the directory of the package, please find the build file (generally in the dist or build folder) and paste the link here, we will download it for you."
+            " contains the directory of the package, please find the build file (generally in the dist or build folder) and paste the link here, I will download it for you."
           );
         },
         when: function(responses) {
@@ -165,75 +173,6 @@ module.exports = class extends Generator {
           return false; // Don't show this prompt if user says that package description is incorrect
         },
         validate: validators.importBuildFileFromNPM
-      },
-      {
-        type: "list",
-        name: "renameOrOverwriteNpm",
-        message: "What do you want to do?",
-        choices: [
-          "Rename the component-dist directory we are making.",
-          "Overwrite the files in the existing component-dist directory."
-        ],
-        when: function(responses) {
-          if (responses.importBuildFileFromNPM === "skip") {
-            return true; // Show this prompt if user says that package description is correct
-          }
-
-          return false; // Don't show this prompt if user says that package description is incorrect
-        }
-      },
-      {
-        type: "input",
-        name: "renameDirectoryNpm",
-        message: `Enter the name of the directory in which you want to import the build file, make sure it is not ${chalk.cyan(
-          "dist"
-        )} or ${chalk.cyan("component-dist")}.`,
-        when: function(responses) {
-          if (
-            responses.renameOrOverwriteNpm ===
-            "Rename the component-dist directory we are making."
-          ) {
-            return true;
-          }
-
-          return false;
-        },
-        validate: validators.renameDirectory
-      },
-      {
-        type: "input",
-        name: "importBuildFileInRenamedDirectoryNpm",
-        message:
-          "Great! Now enter the URL of the build file to import it in the renamed directory.",
-        when: function(responses) {
-          if (
-            responses.renameOrOverwriteNpm ===
-            "Rename the component-dist directory we are making."
-          ) {
-            return true;
-          }
-
-          return false;
-        },
-        validate: validators.importBuildFileInRenamedDirectory
-      },
-      {
-        type: "input",
-        name: "overwriteDirectoryContentNpm",
-        message: `Enter the URL of the build file. Please note that this will overwrite all the existing content in ${chalk.cyan(
-          "component-dist"
-        )}.`,
-        when: function(responses) {
-          if (
-            responses.renameOrOverwriteNpm ===
-            "Overwrite the files in the existing component-dist directory."
-          ) {
-            return true;
-          }
-
-          return false;
-        },
-        validate: validators.overwriteDirectoryContent
       }
     ];
 
@@ -241,78 +180,18 @@ module.exports = class extends Generator {
     const localPrompts = [
       {
         type: "input",
+        name: "directoryName",
+        message: `The build file will be imported in a separate directory in the project's root. Enter the name of this directory or press Enter if you like to go with default ${chalk.cyan(
+          "component-dist"
+        )}.`,
+        validate: validators.directoryName,
+        default: "component-dist"
+      },
+      {
+        type: "input",
         name: "importBuildFileLocally",
         message: "Please enter the path of the build file.",
         validate: validators.importBuildFileLocally
-      },
-      {
-        type: "list",
-        name: "renameOrOverwriteLocal",
-        message: "What do you want to do?",
-        choices: [
-          "Rename the component-dist directory we are making.",
-          "Overwrite the files in the existing component-dist directory."
-        ],
-        when: function(responses) {
-          if (responses.importBuildFileLocally === "skip") {
-            return true; // Show this prompt if user says that package description is correct
-          }
-
-          return false; // Don't show this prompt if user says that package description is incorrect
-        }
-      },
-      {
-        type: "input",
-        name: "renameDirectoryLocal",
-        message: `Enter the name of the directory in which you want to import the build file, make sure it is not ${chalk.cyan(
-          "dist"
-        )} or ${chalk.cyan("component-dist")}.`,
-        when: function(responses) {
-          if (
-            responses.renameOrOverwriteLocal ===
-            "Rename the component-dist directory we are making."
-          ) {
-            return true;
-          }
-
-          return false;
-        },
-        validate: validators.renameDirectory
-      },
-      {
-        type: "input",
-        name: "importBuildFileInRenamedDirectory",
-        message:
-          "Great! Now enter the path of the build file to import it in the renamed directory.",
-        when: function(responses) {
-          if (
-            responses.renameOrOverwriteLocal ===
-            "Rename the component-dist directory we are making."
-          ) {
-            return true;
-          }
-
-          return false;
-        },
-        validate: validators.importBuildFileInRenamedDirectory
-      },
-      {
-        type: "input",
-        name: "overwriteDirectoryContent",
-        message: `Enter the path of the build file. Please note that this will overwrite all the existing content in ${chalk.cyan(
-          "component-dist"
-        )}.`,
-        when: function(responses) {
-          if (
-            responses.renameOrOverwriteLocal ===
-            "Overwrite the files in the existing component-dist directory."
-          ) {
-            return true;
-          }
-
-          return false;
-        },
-        validate: validators.overwriteDirectoryContent
       }
     ];
 
@@ -566,7 +445,7 @@ module.exports = class extends Generator {
       yarn: false
     });
     this.log(
-      `While we install the dependencies, you can read the next steps - \n1. Write the code for your component, instructions are in ${chalk.yellow(
+      `While I install the dependencies, you can read the next steps - \n1. Write the code for your component, instructions are in ${chalk.yellow(
         "src/index.js"
       )}.\n2. Add css styles to your component in ${chalk.yellow(
         "src/style"

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -167,28 +167,73 @@ module.exports = class extends Generator {
         validate: validators.importBuildFileFromNPM
       },
       {
-        type: "input",
-        name: "copyBuildFileFromNPM",
-        message: function(answers) {
-          return (
-            "This URL - " +
-            chalk.bold.yellow(
-              "https://www.jsdelivr.com/package/npm/" +
-                answers.packageName +
-                "?version=" +
-                answers.version
-            ) +
-            " contains the directory of the package, please find the build file (generally in the dist or build folder) and paste the link here, we will download it for you in the existing folder."
-          );
-        },
+        type: "list",
+        name: "renameOrOverwriteNpm",
+        message: "What do you want to do?",
+        choices: [
+          "Rename the component-dist directory we are making.",
+          "Overwrite the files in the existing component-dist directory."
+        ],
         when: function(responses) {
           if (responses.importBuildFileFromNPM === "skip") {
             return true; // Show this prompt if user says that package description is correct
           }
 
           return false; // Don't show this prompt if user says that package description is incorrect
+        }
+      },
+      {
+        type: "input",
+        name: "renameDirectoryNpm",
+        message: `Enter the name of the directory in which you want to import the build file, make sure it is not ${chalk.cyan(
+          "dist"
+        )} or ${chalk.cyan("component-dist")}.`,
+        when: function(responses) {
+          if (
+            responses.renameOrOverwriteNpm ===
+            "Rename the component-dist directory we are making."
+          ) {
+            return true;
+          }
+
+          return false;
         },
-        validate: validators.copyBuildFileFromNPM
+        validate: validators.renameDirectory
+      },
+      {
+        type: "input",
+        name: "importBuildFileInRenamedDirectoryNpm",
+        message:
+          "Great! Now enter the path of the build file to import it in the renamed directory.",
+        when: function(responses) {
+          if (
+            responses.renameOrOverwriteNpm ===
+            "Rename the component-dist directory we are making."
+          ) {
+            return true;
+          }
+
+          return false;
+        },
+        validate: validators.importBuildFileInRenamedDirectory
+      },
+      {
+        type: "input",
+        name: "overwriteDirectoryContentNpm",
+        message: `Enter the path of the build file. Please note that this will overwrite all the existing content in ${chalk.cyan(
+          "component-dist"
+        )}.`,
+        when: function(responses) {
+          if (
+            responses.renameOrOverwriteNpm ===
+            "Overwrite the files in the existing component-dist directory."
+          ) {
+            return true;
+          }
+
+          return false;
+        },
+        validate: validators.overwriteDirectoryContent
       }
     ];
 
@@ -202,7 +247,7 @@ module.exports = class extends Generator {
       },
       {
         type: "list",
-        name: "renameOrOverwrite",
+        name: "renameOrOverwriteLocal",
         message: "What do you want to do?",
         choices: [
           "Rename the component-dist directory we are making.",
@@ -218,13 +263,13 @@ module.exports = class extends Generator {
       },
       {
         type: "input",
-        name: "renameDirectory",
+        name: "renameDirectoryLocal",
         message: `Enter the name of the directory in which you want to import the build file, make sure it is not ${chalk.cyan(
           "dist"
         )} or ${chalk.cyan("component-dist")}.`,
         when: function(responses) {
           if (
-            responses.renameOrOverwrite ===
+            responses.renameOrOverwriteLocal ===
             "Rename the component-dist directory we are making."
           ) {
             return true;
@@ -241,7 +286,7 @@ module.exports = class extends Generator {
           "Great! Now enter the path of the build file to import it in the renamed directory.",
         when: function(responses) {
           if (
-            responses.renameOrOverwrite ===
+            responses.renameOrOverwriteLocal ===
             "Rename the component-dist directory we are making."
           ) {
             return true;
@@ -259,7 +304,7 @@ module.exports = class extends Generator {
         )}.`,
         when: function(responses) {
           if (
-            responses.renameOrOverwrite ===
+            responses.renameOrOverwriteLocal ===
             "Overwrite the files in the existing component-dist directory."
           ) {
             return true;

--- a/generators/app/validator.js
+++ b/generators/app/validator.js
@@ -111,7 +111,7 @@ validators.importBuildFileFromNPM = async function(props) {
       .then(() => {
         return true;
       })
-      .catch(async err => {
+      .catch(err => {
         if (err.code === 1) {
           return chalk.red(
             `Sorry, there already seems to be a directory with the same name ${chalk.cyan(
@@ -145,14 +145,14 @@ validators.importBuildFileFromNPM = async function(props) {
 
 validators.copyBuildFileFromNPM = async props => {
   if (props) {
-    var res = executeCommand(
+    var res = await executeCommand(
       "cd component-dist && curl -O " + props,
       "copyBuildFileFromNPM"
     )
       .then(() => {
         return true;
       })
-      .catch(async err => {
+      .catch(err => {
         if (err.code === 3 || err.code === 23) {
           return chalk.red(
             "The URL is malformed. Please ensure the URL is in correct format."
@@ -180,21 +180,21 @@ validators.importBuildFileLocally = async props => {
       return true;
     }
 
-    var res = executeCommand(
+    var res = await executeCommand(
       "mkdir component-dist && cp " + props + " component-dist",
       "importBuildFileLocally"
     )
       .then(() => {
         return true;
       })
-      .catch(async err => {
+      .catch(err => {
         if (err.code === 1) {
           return chalk.red(
             `Oops! We encountered an error. This can happen due to one of the following reasons - \n\n1) The path of build file entered is incorrect. \n2) There's already a directory named ${chalk.cyan(
               "component-dist"
             )}, in this case please input ${chalk.cyan(
               "skip"
-            )} to paste the build file in your existing directory.\n\nPlease see below for the exact error description - \n${chalk.yellow(
+            )} to rename the new directory or overwrite files in the existing one.\n\nPlease see below for the exact error description - \n${chalk.yellow(
               err
             )}`
           );
@@ -215,21 +215,60 @@ validators.importBuildFileLocally = async props => {
   return chalk.red("This is a mandatory field, please answer.");
 };
 
-validators.copyBuildFileLocally = async props => {
+validators.renameDirectory = async props => {
   if (props) {
-    var res = executeCommand(
-      "cp " + props + " component-dist",
-      "copyBuildFileLocally"
-    )
-      .then(() => {
-        return true;
-      })
-      .catch(async err => {
+    var res = await executeCommand("mkdir " + props)
+      .then(() => true)
+      .catch(err => {
         return chalk.red(
           "Oops! We encountered an error, please see the log below for more details.\n" +
             err
         );
-      }); // Import the build file in component-dist directory locally from computer
+      });
+    return res;
+    /**
+     * Returns true if command execution is successful and proceeds to commonPrompts
+     * returns and logs the error if execution fails
+     */
+  }
+
+  return chalk.red("This is a mandatory field, please answer.");
+};
+
+validators.importBuildFileInRenamedDirectory = async (props, answers) => {
+  if (props) {
+    var res = await executeCommand(
+      "cp " + props + " " + answers.renameDirectory
+    )
+      .then(() => true)
+      .catch(err => {
+        return chalk.red(
+          "Oops! We encountered an error, please see the log below for more details.\n" +
+            err
+        );
+      });
+    return res;
+    /**
+     * Returns true if command execution is successful and proceeds to commonPrompts
+     * returns and logs the error if execution fails
+     */
+  }
+
+  return chalk.red("This is a mandatory field, please answer.");
+};
+
+validators.overwriteDirectoryContent = async props => {
+  if (props) {
+    var res = await executeCommand(
+      "rm -rf component-dist/* && cp " + props + " component-dist"
+    )
+      .then(() => true)
+      .catch(err => {
+        return chalk.red(
+          "Oops! We encountered an error, please see the log below for more details.\n" +
+            err
+        );
+      });
     return res;
     /**
      * Returns true if command execution is successful and proceeds to commonPrompts

--- a/generators/app/validator.js
+++ b/generators/app/validator.js
@@ -116,9 +116,9 @@ validators.importBuildFileFromNPM = async function(props) {
           return chalk.red(
             `Sorry, there already seems to be a directory with the same name ${chalk.cyan(
               "(component-dist)"
-            )}, please change it's name or move it.\n   If you want to just copy this file into that directory, enter ${chalk.cyan(
+            )}, please input ${chalk.cyan(
               "skip"
-            )}.\n`
+            )} to rename the directory in which build file will be imported or overwrite the contents of the existing directory.\n`
           );
         }
 


### PR DESCRIPTION
## Description
Adds option to rename the build directory or overwrite the content of component-build if it already exists in local workflow.
It also adds test for the new prompts. See the final workflow below.

![Final workflow](https://user-images.githubusercontent.com/31413407/61964945-b5474400-afec-11e9-8f97-222414aa3d4e.png)


## Checklist
- [x] Run the tests
