### PR TITLE
Fixed css bug - custom styles not added to component

### DIFF
--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -34,7 +34,7 @@ describe("generator-biojs-webcomponents:app - Make a new Web Component", () => {
     assert.fileContent([
       [
         "examples/index.html",
-        '<test-component-tool geneId="BRCA1"></test-component-tool>'
+        '<test-component-tool geneId="BRCA1" class="BiojsTestComponent"></test-component-tool>'
       ],
       ["examples/index.html", "<h1>Biojs test component demo</h1>"],
       ["src/index.js", "define('test-component-tool', BiojsTestComponent);"],
@@ -53,7 +53,7 @@ describe("generator-biojs-webcomponents:app - Make a new Web Component", () => {
         assert.fileContent([
           [
             "examples/index.html",
-            '<biojs-webcomponent-tool-name-here geneId="BRCA1"></biojs-webcomponent-tool-name-here>'
+            '<biojs-webcomponent-tool-name-here geneId="BRCA1" class="BioJSComponent"></biojs-webcomponent-tool-name-here>'
           ],
           ["examples/index.html", "<h1>BioJS component demo</h1>"],
           [

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -378,7 +378,8 @@ module.exports = class extends Generator {
       this.destinationPath("examples/index.html"),
       {
         title: this.props.toolNameHuman,
-        toolNameComputer: this.props.toolNameComputer
+        toolNameComputer: this.props.toolNameComputer,
+        toolNameCamel: this.props.toolNameCamel
       }
     );
     this.fs.copyTpl(

--- a/generators/app/templates/examples/index.html
+++ b/generators/app/templates/examples/index.html
@@ -27,7 +27,7 @@
 
   <!-- the geneId param below can be removed if needed - it's just an example of
        how to pass values to the component's JS behaviours. -->
-  <<%= toolNameComputer %> geneId="BRCA1"></<%= toolNameComputer %>>
+  <<%= toolNameComputer %> geneId="BRCA1" class="<%= toolNameCamel %>"></<%= toolNameComputer %>>
 
 </body>
 


### PR DESCRIPTION
## Description
The custom styles that were added for the component were not working because the class attribute was not added to the component. This fixes that and hence, any styles added in style.less will work.

## Related issues and discussion
#4 

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the tests