### PR TITLE
Added option to run generator in directory mentioned in arg

### DIFF
--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -85,13 +85,15 @@ describe("generator-biojs-webcomponents:app - Upgrade an existing component by i
       .then(() => assert.file(["component-dist"]));
   });
   it("imports the build file", async () => {
-    await validators
-      .importBuildFileLocally(
-        path.join(__dirname, "../generators/app/validator.js")
-      )
-      .then(() => {
-        assert.file(["component-dist/validator.js"]);
-      });
+    await validators.storeArg("web-component").then(async () => {
+      await validators
+        .importBuildFileLocally(
+          path.join(__dirname, "../generators/app/validator.js")
+        )
+        .then(() => {
+          assert.file(["web-component/component-dist/validator.js"]);
+        });
+    });
   });
   it("throws an error if user enters an empty string as path of build file", async () => {
     assert.equal(

--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -13,7 +13,6 @@ describe("generator-biojs-webcomponents:app - Make a new Web Component", () => {
       toolNameHuman: "Biojs test component"
     });
   });
-
   it("creates expected files", () => {
     assert.file([
       "examples/index.html",
@@ -79,21 +78,24 @@ describe("generator-biojs-webcomponents:app - Make a new Web Component", () => {
 });
 
 describe("generator-biojs-webcomponents:app - Upgrade an existing component by importing build file locally", () => {
+  it("runs the generator in the directory passed in arguments", async () => {
+    await validators.storeArg("test-component").then(() => {
+      assert.file("test-component");
+    });
+  });
   it("makes a new directory named - component-dist", async () => {
     await validators
       .directoryName("component-dist")
-      .then(() => assert.file(["component-dist"]));
+      .then(() => assert.file(["test-component/component-dist"]));
   });
   it("imports the build file", async () => {
-    await validators.storeArg("web-component").then(async () => {
-      await validators
-        .importBuildFileLocally(
-          path.join(__dirname, "../generators/app/validator.js")
-        )
-        .then(() => {
-          assert.file(["web-component/component-dist/validator.js"]);
-        });
-    });
+    await validators
+      .importBuildFileLocally(
+        path.join(__dirname, "../generators/app/validator.js")
+      )
+      .then(() => {
+        assert.file(["test-component/component-dist/validator.js"]);
+      });
   });
   it("throws an error if user enters an empty string as path of build file", async () => {
     assert.equal(

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -5,6 +5,15 @@ const yosay = require("yosay");
 const validators = require("./validator");
 
 module.exports = class extends Generator {
+  // Note: arguments and options should be defined in the constructor.
+  constructor(args, opts) {
+    super(args, opts);
+    this.argument("projectDirectory", { type: String, required: false });
+    if (!this.options.projectDirectory) {
+      this.options.projectDirectory = "web-component";
+    }
+  }
+
   initializing() {
     this.composeWith(require.resolve("generator-license"), {
       defaultLicense: "MIT" // (optional) Select a default license
@@ -23,6 +32,12 @@ module.exports = class extends Generator {
 
     // First prompt
     const initialPrompts = [
+      {
+        type: "input",
+        name: "start",
+        message: "Press any key to get going!",
+        validate: () => validators.storeArg(this.options.projectDirectory)
+      },
       {
         type: "list",
         name: "upgradeOrMake",
@@ -289,7 +304,7 @@ module.exports = class extends Generator {
       return this.prompt(initialPrompts).then(props => {
         // To access props later use this.props.someAnswer;
         // If user chooses to upgrade an existing component
-        if (props.upgradeOrMake === initialPrompts[0].choices[0]) {
+        if (props.upgradeOrMake === initialPrompts[1].choices[0]) {
           return this.prompt(upgradeComponentPrompts).then(props => {
             // If user chooses to import file locally from computer
             if (props.importFrom === upgradeComponentPrompts[0].choices[0]) {
@@ -339,7 +354,7 @@ module.exports = class extends Generator {
         }
 
         // If user chooses to make a new component
-        if (props.upgradeOrMake === initialPrompts[0].choices[1]) {
+        if (props.upgradeOrMake === initialPrompts[1].choices[1]) {
           return this.prompt(commonPrompts).then(props => {
             this.props = props;
             this.props.toolNameCamel = toCamelCase(props.toolNameHuman);
@@ -352,6 +367,7 @@ module.exports = class extends Generator {
   }
 
   writing() {
+    this.destinationRoot(`./${this.options.projectDirectory}`);
     this.fs.copyTpl(
       this.templatePath("examples/index.html"),
       this.destinationPath("examples/index.html"),
@@ -436,6 +452,7 @@ module.exports = class extends Generator {
       this.templatePath("img/favicon.png"),
       this.destinationPath("img/favicon.png")
     );
+    this.destinationRoot("./");
   }
 
   install() {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -203,7 +203,8 @@ module.exports = class extends Generator {
       {
         type: "input",
         name: "directoryName",
-        message: "The build file will be imported in a separate directory in the project's root. Enter the name of this directory or press Enter if you like to go with default.",
+        message:
+          "The build file will be imported in a separate directory in the project's root. Enter the name of this directory or press Enter if you like to go with default.",
         validate: validators.directoryName,
         default: "component-dist"
       },

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -163,6 +163,13 @@ module.exports = class extends Generator {
         message:
           "The build file will be imported in a separate directory in the project's root. Enter the name of this directory or press Enter if you like to go with default.",
         validate: validators.directoryName,
+        when: function(responses) {
+          if (responses.confirmPackageName) {
+            return true; // Show this prompt if user says that package description is correct
+          }
+
+          return false; // Don't show this prompt if user says that package description is incorrect
+        },
         default: "component-dist"
       },
       {
@@ -251,7 +258,6 @@ module.exports = class extends Generator {
               ); // Call the function recursively
             }
 
-            // If user chooses to install component from npm after starting over
             return this.prompt(commonPrompts).then(props => {
               this.props = props;
               this.props.toolNameCamel = toCamelCase(props.toolNameHuman);
@@ -283,30 +289,20 @@ module.exports = class extends Generator {
               ); // Call the function recursively
             }
 
-            // If user chooses to import from npm after starting over
             return this.prompt(commonPrompts).then(props => {
               this.props = props;
               this.props.toolNameCamel = toCamelCase(props.toolNameHuman);
             });
           });
         }
-
-        // If user chooses to import file locally when package description is incorrect
-        return this.prompt(localPrompts).then(() => {
-          return this.prompt(commonPrompts).then(props => {
-            this.props = props;
-            this.props.toolNameCamel = toCamelCase(props.toolNameHuman);
-          });
-        });
       }
 
       // Normal (initial) prompt execution
       return this.prompt(initialPrompts).then(props => {
-        // To access props later use this.props.someAnswer;
         // If user chooses to upgrade an existing component
         if (props.upgradeOrMake === initialPrompts[1].choices[0]) {
           return this.prompt(upgradeComponentPrompts).then(props => {
-            // If user chooses to import file locally from computer
+            // If user chooses to install component as npm package
             if (props.importFrom === upgradeComponentPrompts[0].choices[0]) {
               return this.prompt(installNpmPackagePrompts).then(props => {
                 // If user chooses to go back and choose source of importing file again
@@ -316,7 +312,6 @@ module.exports = class extends Generator {
                   ); // Call the function recursively
                 }
 
-                // If user chooses to install component from npm initially
                 return this.prompt(commonPrompts).then(props => {
                   this.props = props;
                   this.props.toolNameCamel = toCamelCase(props.toolNameHuman);
@@ -324,6 +319,7 @@ module.exports = class extends Generator {
               });
             }
 
+            // If user chooses to import build file locally
             if (props.importFrom === upgradeComponentPrompts[0].choices[1]) {
               return this.prompt(localPrompts).then(() => {
                 return this.prompt(commonPrompts).then(props => {
@@ -333,17 +329,16 @@ module.exports = class extends Generator {
               });
             }
 
+            // If user chooses to import build file from npm package
             if (props.importFrom === upgradeComponentPrompts[0].choices[2]) {
-              // If user chooses to import file from npm
               return this.prompt(npmPrompts).then(props => {
-                // If user chooses to go back and choose source of importing file again
+                // If user chooses to go back and choose source of importing again
                 if (props.changeImportSourceFromNpmBuildFile) {
                   return recursivePromptExecution(
                     props.changeImportSourceFromNpmBuildFile
                   ); // Call the function recursively
                 }
 
-                // If user chooses to import from npm initially
                 return this.prompt(commonPrompts).then(props => {
                   this.props = props;
                   this.props.toolNameCamel = toCamelCase(props.toolNameHuman);

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -58,7 +58,7 @@ module.exports = class extends Generator {
         message:
           "I need the build file (generally index.js, main.js or componentName.js) for this, import it using one of the options -",
         choices: [
-          "Install component from npm package (Recommended - fastest way)",
+          "Install component from npm package. (Recommended - fastest way)",
           "Tell us the path of the build file on your local machine and I will import it in the project.",
           "Tell us the npm package name, version, build file URL and I will download the build file."
         ],
@@ -83,7 +83,7 @@ module.exports = class extends Generator {
         name: "changeImportSourceFromNpmPackage",
         message: "What do you want to do?",
         choices: [
-          "Enter package name again to install component from npm package.",
+          "Enter package name again to install component from npm package. (Recommended - fastest way)",
           "Import the file locally from your computer.",
           "Enter package name, version, build file URL to download the build file."
         ],
@@ -130,7 +130,7 @@ module.exports = class extends Generator {
         name: "changeImportSourceFromNpmBuildFile",
         message: "What do you want to do?",
         choices: [
-          "Enter package name again to install component from npm package.",
+          "Enter package name again to install component from npm package. (Recommended - fastest way)",
           "Import the file locally from your computer.",
           "Enter package name, version, build file URL to download the build file."
         ],
@@ -203,9 +203,7 @@ module.exports = class extends Generator {
       {
         type: "input",
         name: "directoryName",
-        message: `The build file will be imported in a separate directory in the project's root. Enter the name of this directory or press Enter if you like to go with default ${chalk.cyan(
-          "component-dist"
-        )}.`,
+        message: "The build file will be imported in a separate directory in the project's root. Enter the name of this directory or press Enter if you like to go with default.",
         validate: validators.directoryName,
         default: "component-dist"
       },

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -8,10 +8,14 @@ module.exports = class extends Generator {
   // Note: arguments and options should be defined in the constructor.
   constructor(args, opts) {
     super(args, opts);
-    this.argument("projectDirectory", { type: String, required: false });
-    if (!this.options.projectDirectory) {
-      this.options.projectDirectory = "web-component";
-    }
+    this.argument("projectDirectory", {
+      type: String,
+      required: false,
+      default: "web-component",
+      desc: `${chalk.blue(
+        "path of the project directory, if you enter the path of a directory which does not exist, the generator will make one for you, otherwise it will use the existing one."
+      )} Default directory: ${chalk.cyan("web-component")}`
+    });
   }
 
   initializing() {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -35,7 +35,7 @@ module.exports = class extends Generator {
       {
         type: "input",
         name: "start",
-        message: "Press any key to get going!",
+        message: "Press Enter key to get going!",
         validate: () => validators.storeArg(this.options.projectDirectory)
       },
       {

--- a/generators/app/validator.js
+++ b/generators/app/validator.js
@@ -292,8 +292,8 @@ function executeCommand(command, type) {
           reject(err);
         }
       } else if (type === "checkDirExistence") {
-          spinner.stop();
-          resolve(true);
+        spinner.stop();
+        resolve(true);
       } else if (stdout) {
         process.stdout.write(`\n ${stdout} \n`); // If there is an output display it
         spinner.stop();

--- a/generators/app/validator.js
+++ b/generators/app/validator.js
@@ -9,6 +9,10 @@ let projectDirectory;
 
 validators.storeArg = async function(props) {
   projectDirectory = props;
+  if (projectDirectory.trim() === ".") {
+    return true;
+  }
+
   var res = await executeCommand("mkdir " + projectDirectory)
     .then(() => true)
     .catch(err => {
@@ -252,14 +256,6 @@ function executeCommand(command, type) {
     spinner: "weather"
   });
   spinner.start();
-  if (type === "projectDirectory") {
-    if (command === "." || command.trim() === "") {
-      command = "mkdir webcomponent && cd webcomponent";
-    } else {
-      command = "mkdir " + command + " && cd " + command;
-    }
-  }
-
   return new Promise((resolve, reject) => {
     exec(command, (err, stdout) => {
       if (err) {

--- a/generators/app/validator.js
+++ b/generators/app/validator.js
@@ -140,7 +140,7 @@ validators.checkVersionAndInstallComponent = async function(props, answers) {
 
 validators.directoryName = async props => {
   var res;
-  if (props.trim() === "o") {
+  if (props.trim() === "o" || props.trim() === "O") {
     res = await executeCommand(`rm -rf ${projectDirectory}/${buildDirectory}/*`)
       .then(() => true)
       .catch(err => {

--- a/generators/app/validator.js
+++ b/generators/app/validator.js
@@ -17,8 +17,9 @@ validators.storeArg = async function(props) {
     .then(() => true)
     .catch(err => {
       return chalk.red(
-        "Oops! We encountered an error, please see the log below for more details.\n" +
+        `Oops! We encountered an error. Please see below for the more details - \n${chalk.yellow(
           err
+        )}\nIf the directory whose path you entered already exists and you want that to be your project directory, cd into that directory and run ${chalk.cyan("`yo @biojs/biojs-webcomponents .`")}.`
       );
     });
   return res;
@@ -89,7 +90,7 @@ validators.checkVersionAndInstallComponent = async function(props, answers) {
     var res = await executeCommand(command, "version")
       .then(async () => {
         var res = await executeCommand(
-          "npm i " + answers.packageNameToInstallComponent + "@" + props,
+          "cd " + projectDirectory + " && npm i " + answers.packageNameToInstallComponent + "@" + props + " --save-exact",
           "checkVersionAndInstallComponent"
         )
           .then(() => true)

--- a/generators/app/validator.js
+++ b/generators/app/validator.js
@@ -15,12 +15,22 @@ validators.storeArg = async function(props) {
 
   var res = await executeCommand("mkdir " + projectDirectory)
     .then(() => true)
-    .catch(err => {
-      return chalk.red(
-        `Oops! We encountered an error. Please see below for the more details - \n${chalk.yellow(
-          err
-        )}\nIf the directory whose path you entered already exists and you want that to be your project directory, cd into that directory and run ${chalk.cyan("`yo @biojs/biojs-webcomponents .`")}.`
-      );
+    .catch(async () => {
+      var tryAgain = await executeCommand(
+        "ls " + projectDirectory,
+        "checkDirExistence"
+      )
+        .then(() => true)
+        .catch(err => {
+          return chalk.red(
+            `Oops! We encountered an error. Please see below for the more details - \n${chalk.yellow(
+              err
+            )}\n.Try this - cd into that directory and run ${chalk.cyan(
+              "`yo @biojs/biojs-webcomponents .`"
+            )}.`
+          );
+        });
+      return tryAgain;
     });
   return res;
 };
@@ -90,7 +100,13 @@ validators.checkVersionAndInstallComponent = async function(props, answers) {
     var res = await executeCommand(command, "version")
       .then(async () => {
         var res = await executeCommand(
-          "cd " + projectDirectory + " && npm i " + answers.packageNameToInstallComponent + "@" + props + " --save-exact",
+          "cd " +
+            projectDirectory +
+            " && npm i " +
+            answers.packageNameToInstallComponent +
+            "@" +
+            props +
+            " --save-exact",
           "checkVersionAndInstallComponent"
         )
           .then(() => true)
@@ -125,7 +141,7 @@ validators.checkVersionAndInstallComponent = async function(props, answers) {
 validators.directoryName = async props => {
   var res;
   if (props.trim() === "o") {
-    res = await executeCommand(`rm -rf ${buildDirectory}/*`)
+    res = await executeCommand(`rm -rf ${projectDirectory}/${buildDirectory}/*`)
       .then(() => true)
       .catch(err => {
         return chalk.red(
@@ -139,13 +155,13 @@ validators.directoryName = async props => {
 
   if (props) {
     buildDirectory = props;
-    res = await executeCommand("mkdir " + props)
+    res = await executeCommand("mkdir " + projectDirectory + "/" + props)
       .then(() => true)
       .catch(err => {
         return chalk.red(
           "Uh oh! There already exists a directory with the same name. Enter a new name again or enter " +
             chalk.cyan("o") +
-            " if you want to overwrite the contents of this directory and then import the build file. please see the log below for more details.\n" +
+            " if you want to overwrite the contents of this directory and then import the build file. Please see the log below for more details.\n" +
             chalk.yellow(err)
         );
       });
@@ -275,6 +291,9 @@ function executeCommand(command, type) {
           spinner.stop();
           reject(err);
         }
+      } else if (type === "checkDirExistence") {
+          spinner.stop();
+          resolve(true);
       } else if (stdout) {
         process.stdout.write(`\n ${stdout} \n`); // If there is an output display it
         spinner.stop();


### PR DESCRIPTION
## Description
This adds the option to run the generator in the directory mentioned in the argument. Also changes the tests accordingly.

1. `yo @biojs/biojs-webcomponents` will run the generator in a new directory named `web-component` in the current directory. If this directory already exists, the generator will run in the existing one.

2. `yo @biojs/biojs-webcomponents .` will run the generator in the current directory.

3. `yo @biojs/biojs-webcomponents /pathToDIrectory` will run the generator in the directory whose path is passed. If the directory whose path is passed doesn't exist, the generator will create a new directory.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the tests