### PR TITLE
Fixed - Do not check for version if user enters latest

### DIFF
--- a/generators/app/validator.js
+++ b/generators/app/validator.js
@@ -69,6 +69,10 @@ validators.packageName = async function(props) {
 
 validators.version = async function(props, answers) {
   if (props) {
+    if (props === "latest") {
+      return true;
+    }
+
     let command = "npm view " + answers.packageName + "@" + props;
     let res = await executeCommand(command, "version")
       .then(() => {
@@ -95,6 +99,28 @@ validators.version = async function(props, answers) {
 
 validators.checkVersionAndInstallComponent = async function(props, answers) {
   if (props) {
+    if (props === "latest") {
+      let res = await executeCommand(
+        "cd " +
+          projectDirectory +
+          " && npm i " +
+          answers.packageNameToInstallComponent +
+          "@" +
+          props +
+          " --save-exact",
+        "checkVersionAndInstallComponent"
+      )
+        .then(() => true)
+        .catch(err => {
+          return chalk.red(
+            `Oops! We encountered an error. Please see below for the more details - \n${chalk.yellow(
+              err
+            )}`
+          );
+        });
+      return res;
+    }
+
     let command =
       "npm view " + answers.packageNameToInstallComponent + "@" + props;
     let res = await executeCommand(command, "version")


### PR DESCRIPTION
## Description
If the version is latest, the generator does need not check if its valid as `latest` automatically means the latest version on npm. This saves time.

## Related issues and discussion
#26 

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the tests
